### PR TITLE
retrieve ghost inspector created records to delete

### DIFF
--- a/Infrastructure/Scripts/ghost_inspector_signups.sql
+++ b/Infrastructure/Scripts/ghost_inspector_signups.sql
@@ -1,0 +1,7 @@
+SELECT DISTINCT s.id
+FROM rogue.signups s
+INNER JOIN  
+	(SELECT g.id
+	FROM rogue.signups g
+	WHERE g.why_participated = 'why_participated_ghost_test') ghost ON s.id = ghost.id
+


### PR DESCRIPTION
Rogue has been running ghost inspector runscope tests. These generate signups with signups.why_participated = 'why_participated_ghost_test'. Unfortunately, they seem to be generating additional signups that don't have the same value in why participated. These need to be purged manually until Team Bleed figures out how to atomically declare test records as such