### PR TITLE
final campaign_activity

### DIFF
--- a/Infrastructure/Scripts/derived_tables/campaign_activity.sql
+++ b/Infrastructure/Scripts/derived_tables/campaign_activity.sql
@@ -1,20 +1,5 @@
-SELECT  
-	a.northstar_id AS northstar_id,
-	a.id AS signup_id,
-	b.id AS post_id,
-	a.campaign_id AS campaign_id,
-	a.campaign_run_id AS campaign_run_id,
-	b.type AS post_type,
-	b.status AS post_status,
-	a.why_participated AS why_participated,
-	b.quantity AS quantity,
-	a.source AS signup_source,
-	b.source AS post_source,
-	a.created_at AS signup_created_at,
-	b.created_at AS post_created_at,
-	c.reported_back AS reported_back,
-	b.url AS url
-FROM 
+
+CREATE MATERIALIZED VIEW public.signups AS 
 	(SELECT 
 		sd.northstar_id AS northstar_id,
 		sd.id AS id,
@@ -24,20 +9,23 @@ FROM
 		sd."source" AS "source",
 		sd.created_at AS created_at
 	FROM 
-        (SELECT 
-        		stemp.id,
-        		max(stemp.updated_at) AS updated_at
-        FROM rogue.signups stemp
-        WHERE stemp.deleted_at IS NULL
-        AND stemp."source" IS DISTINCT FROM 'runscope'
-     	AND stemp."source" IS DISTINCT FROM 'runscope-oauth'
-     	AND stemp.why_participated IS DISTINCT FROM 'why_participated_ghost_test'
-        GROUP BY stemp.id) 
-        s_maxupt
+	    (SELECT 
+	    		stemp.id,
+	    		max(stemp.updated_at) AS updated_at
+	    FROM rogue.signups stemp
+	    WHERE stemp.deleted_at IS NULL
+	    AND stemp."source" IS DISTINCT FROM 'runscope'
+	 	AND stemp."source" IS DISTINCT FROM 'runscope-oauth'
+	 	AND stemp.why_participated IS DISTINCT FROM 'why_participated_ghost_test'
+	    GROUP BY stemp.id) 
+	    s_maxupt
 		INNER JOIN rogue.signups sd
-			ON sd.id = s_maxupt.id AND sd.updated_at = s_maxupt.updated_at	
-	) a
-LEFT JOIN 
+			ON sd.id = s_maxupt.id AND sd.updated_at = s_maxupt.updated_at
+	)
+	; 
+CREATE INDEX signup_source ON public.signups (id); 
+
+CREATE MATERIALIZED VIEW public.posts AS
 	(SELECT 
 		pd.id AS id,
 		pd."type" AS type,
@@ -53,21 +41,55 @@ LEFT JOIN
 	        max(ptemp.updated_at) AS updated_at
      	FROM rogue.posts ptemp
      	WHERE ptemp.deleted_at IS NULL
-     	AND ptemp.SOURCE IS DISTINCT FROM 'runscope'
-     	AND ptemp.SOURCE IS DISTINCT FROM 'runscope-oauth'
+     	AND ptemp."source" IS DISTINCT FROM 'runscope'
+     	AND ptemp."source" IS DISTINCT FROM 'runscope-oauth'
         GROUP BY ptemp.id) 
 	    p_maxupt
 	    INNER JOIN rogue.posts pd
-			ON pd.id = p_maxupt.id AND pd.updated_at = p_maxupt.updated_at        
-	) b
-	ON b.signup_id = a.id
-LEFT JOIN 
+			ON pd.id = p_maxupt.id AND pd.updated_at = p_maxupt.updated_at  
+	)
+	;
+CREATE INDEX post_index ON public.posts (id)
+; 
+
+CREATE MATERIALIZED VIEW public.reported_back AS 
 	(SELECT 
 		temp_posts.signup_id,
 		MAX(CASE WHEN temp_posts.id <> -1 then 1 else 0 end) AS reported_back
 	FROM 
 		rogue.posts temp_posts
+	WHERE temp_posts.signup_id IS NOT NULL
 	GROUP BY 
 		temp_posts.signup_id
-	) c
-	ON c.signup_id = a.id
+	) 
+	; 
+CREATE INDEX reported_back_index ON public.reported_back (temp_posts.signup_id)
+;
+
+CREATE MATERIALIZED VIEW public.campaign_activity AS 
+	(SELECT  
+		a.northstar_id AS northstar_id,
+		a.id AS signup_id,
+		b.id AS post_id,
+		a.campaign_id AS campaign_id,
+		a.campaign_run_id AS campaign_run_id,
+		b.type AS post_type,
+		b.status AS post_status,
+		a.why_participated AS why_participated,
+		b.quantity AS quantity,
+		a.source AS signup_source,
+		b.source AS post_source,
+		a.created_at AS signup_created_at,
+		b.created_at AS post_created_at,
+		c.reported_back AS reported_back,
+		b.url AS url
+	FROM 
+		public.signups a
+	LEFT JOIN 
+		public.posts b
+		ON b.signup_id = a.id
+	LEFT JOIN 
+		public.reported_back c
+		ON c.signup_id = a.id
+	)
+	;

--- a/Infrastructure/Scripts/derived_tables/campaign_activity.sql
+++ b/Infrastructure/Scripts/derived_tables/campaign_activity.sql
@@ -1,4 +1,4 @@
-
+DROP MATERIALIZED VIEW IF EXISTS public.signups CASCADE;
 CREATE MATERIALIZED VIEW public.signups AS 
 	(SELECT 
 		sd.northstar_id AS northstar_id,
@@ -24,7 +24,7 @@ CREATE MATERIALIZED VIEW public.signups AS
 	)
 	; 
 CREATE INDEX signup_source ON public.signups (id); 
-
+DROP MATERIALIZED VIEW IF EXISTS public.posts CASCADE;
 CREATE MATERIALIZED VIEW public.posts AS
 	(SELECT 
 		pd.id AS id,
@@ -49,9 +49,8 @@ CREATE MATERIALIZED VIEW public.posts AS
 			ON pd.id = p_maxupt.id AND pd.updated_at = p_maxupt.updated_at  
 	)
 	;
-CREATE INDEX post_index ON public.posts (id)
-; 
-
+CREATE INDEX post_index ON public.posts (id); 
+DROP MATERIALIZED VIEW IF EXISTS public.reported_back CASCADE;
 CREATE MATERIALIZED VIEW public.reported_back AS 
 	(SELECT 
 		temp_posts.signup_id,
@@ -63,9 +62,8 @@ CREATE MATERIALIZED VIEW public.reported_back AS
 		temp_posts.signup_id
 	) 
 	; 
-CREATE INDEX reported_back_index ON public.reported_back (temp_posts.signup_id)
-;
-
+CREATE INDEX reported_back_index ON public.reported_back (signup_id);
+DROP MATERIALIZED VIEW IF EXISTS public.campaign_activity;
 CREATE MATERIALIZED VIEW public.campaign_activity AS 
 	(SELECT  
 		a.northstar_id AS northstar_id,
@@ -93,3 +91,8 @@ CREATE MATERIALIZED VIEW public.campaign_activity AS
 		ON c.signup_id = a.id
 	)
 	;
+CREATE INDEX ON public.campaign_activity (northstar_id, signup_id, post_id);
+GRANT SELECT ON public.campaign_activity TO looker;
+GRANT SELECT ON public.campaign_activity TO jjensen;
+GRANT SELECT ON public.campaign_activity TO jli;
+GRANT SELECT ON public.campaign_activity TO shasan;

--- a/Infrastructure/Scripts/derived_tables/campaign_activity.sql
+++ b/Infrastructure/Scripts/derived_tables/campaign_activity.sql
@@ -2,45 +2,71 @@ SELECT
 	a.northstar_id AS northstar_id,
 	a.id AS signup_id,
 	b.id AS post_id,
-	b.quantity AS quantity,
 	a.campaign_id AS campaign_id,
+	a.campaign_run_id AS campaign_run_id,
+	b.type AS post_type,
+	b.status AS post_status,
+	a.why_participated AS why_participated,
+	b.quantity AS quantity,
 	a.source AS signup_source,
 	b.source AS post_source,
 	a.created_at AS signup_created_at,
 	b.created_at AS post_created_at,
 	c.reported_back AS reported_back,
+	b.url AS url
 FROM 
-	(SELECT *
+	(SELECT 
+		sd.northstar_id AS northstar_id,
+		sd.id AS id,
+		sd.campaign_id AS campaign_id,
+		sd.campaign_run_id AS campaign_run_id,
+		sd.why_participated AS why_participated,
+		sd.SOURCE AS SOURCE,
+		sd.created_at AS created_at
 	FROM 
-		rogue.signups s
-	WHERE 
-		s.updated_at = MAX(updated_at)
-	GROUP BY 
-		s.id
+        (SELECT 
+        		stemp.id,
+        		max(stemp.updated_at) AS updated_at
+        FROM rogue.signups stemp
+        WHERE stemp.deleted_at IS NULL
+        AND stemp.SOURCE IS DISTINCT FROM 'runscope'
+     	AND stemp.SOURCE IS DISTINCT FROM 'runscope-oauth'
+        GROUP BY stemp.id) 
+        s_maxupt
+		INNER JOIN rogue.signups sd
+			ON sd.id = s_maxupt.id AND sd.updated_at = s_maxupt.updated_at	
 	) a
 LEFT JOIN 
-	(SELECT *
+	(SELECT 
+		pd.id AS id,
+		pd.TYPE AS TYPE,
+		pd.status AS status,
+		pd.quantity AS quantity,
+		pd.SOURCE AS SOURCE,
+		pd.created_at AS created_at,
+		pd.url AS url,
+		pd.signup_id AS signup_id
 	FROM 
-		rogue.posts p
-	WHERE 
-		p.updated_at = MAX(p.updated_at)
-	GROUP BY 
-		p.id
+		(SELECT 
+	        ptemp.id,
+	        max(ptemp.updated_at) AS updated_at
+     	FROM rogue.posts ptemp
+     	WHERE ptemp.deleted_at IS NULL
+     	AND ptemp.SOURCE IS DISTINCT FROM 'runscope'
+     	AND ptemp.SOURCE IS DISTINCT FROM 'runscope-oauth'
+        GROUP BY ptemp.id) 
+	    p_maxupt
+	    INNER JOIN rogue.posts pd
+			ON pd.id = p_maxupt.id AND pd.updated_at = p_maxupt.updated_at        
 	) b
 	ON b.signup_id = a.id
 LEFT JOIN 
 	(SELECT 
 		temp_posts.signup_id,
-		MAX(CASE WHEN temp_posts.post_id <> -1 then 1 else 0 end) AS reported_back
+		MAX(CASE WHEN temp_posts.id <> -1 then 1 else 0 end) AS reported_back
 	FROM 
 		rogue.posts temp_posts
 	GROUP BY 
 		temp_posts.signup_id
 	) c
 	ON c.signup_id = a.id
-WHERE s.SOURCE IS DISTINCT FROM 'runscope'
-AND s.SOURCE IS DISTINCT FROM 'runscope-oauth'
-AND s.deleted_at IS NULL
-
-	
-	

--- a/Infrastructure/Scripts/derived_tables/campaign_activity.sql
+++ b/Infrastructure/Scripts/derived_tables/campaign_activity.sql
@@ -21,7 +21,7 @@ FROM
 		sd.campaign_id AS campaign_id,
 		sd.campaign_run_id AS campaign_run_id,
 		sd.why_participated AS why_participated,
-		sd.SOURCE AS SOURCE,
+		sd."source" AS "source",
 		sd.created_at AS created_at
 	FROM 
         (SELECT 
@@ -29,8 +29,9 @@ FROM
         		max(stemp.updated_at) AS updated_at
         FROM rogue.signups stemp
         WHERE stemp.deleted_at IS NULL
-        AND stemp.SOURCE IS DISTINCT FROM 'runscope'
-     	AND stemp.SOURCE IS DISTINCT FROM 'runscope-oauth'
+        AND stemp."source" IS DISTINCT FROM 'runscope'
+     	AND stemp."source" IS DISTINCT FROM 'runscope-oauth'
+     	AND stemp.why_participated IS DISTINCT FROM 'why_participated_ghost_test'
         GROUP BY stemp.id) 
         s_maxupt
 		INNER JOIN rogue.signups sd
@@ -39,10 +40,10 @@ FROM
 LEFT JOIN 
 	(SELECT 
 		pd.id AS id,
-		pd.TYPE AS TYPE,
+		pd."type" AS type,
 		pd.status AS status,
 		pd.quantity AS quantity,
-		pd.SOURCE AS SOURCE,
+		pd."source" AS source,
 		pd.created_at AS created_at,
 		pd.url AS url,
 		pd.signup_id AS signup_id


### PR DESCRIPTION
I added an interesting postgres feature to the 'DROP MAT VIEW' statement  -- CASCADE, which drops the view throughout all appearances so that it removes dependencies. I believe I did this correctly, but would be helpful if you could review. 