### PR TITLE
Remove voter-reg posts from rogue.posts in MEL

### DIFF
--- a/Infrastructure/Scripts/derived_tables/MEL_v3.sql
+++ b/Infrastructure/Scripts/derived_tables/MEL_v3.sql
@@ -49,7 +49,8 @@ CREATE MATERIALIZED VIEW public.member_event_log AS
                 pd.created_at,
                 pd.id,
                 pd."source",
-                pd.deleted_at
+                pd.deleted_at,
+                pd."type"
             FROM 
 				(SELECT 
                     ptemp.id,
@@ -60,6 +61,7 @@ CREATE MATERIALIZED VIEW public.member_event_log AS
             ON pd.id = p_maxupt.id AND pd.updated_at = p_maxupt.updated_at
                 ) p
         WHERE p.deleted_at IS NULL
+        AND p."type" IS DISTINCT FROM 'voter-reg'
 	UNION ALL -- SITE ACCESS
         SELECT DISTINCT 
             u_access.id AS northstar_id,


### PR DESCRIPTION
They are included in MEL when we bring the turbovote file, and are coming into posts. They also have the wrong timestamp because they are use chompy imported date. This resolves both issues.

https://www.pivotaltracker.com/story/show/158030901