### PR TITLE
add bertly to MEL

### DIFF
--- a/Infrastructure/Scripts/derived_tables/MEL_v3.sql
+++ b/Infrastructure/Scripts/derived_tables/MEL_v3.sql
@@ -149,15 +149,15 @@ CREATE MATERIALIZED VIEW public.member_event_log AS
         AND pe.northstar_id IS NOT NULL
         AND pe.northstar_id <> ''
 	UNION ALL 
-    		SELECT -- SMS LINK CLICKS FROM BERTLY
-    			b.northstar_id AS northstar_id,
-    			b.click_time AS "timestamp",
-    			'sms_link_click' AS "action",
-    			'10' AS action_id,
-    			'bertly' AS "source",
-    			b.click_id AS action_serial_id
-    		FROM public.bertly_clicks b	
-    		WHERE b.northstar_id IS NOT NULL 
+    	SELECT DISTINCT -- SMS LINK CLICKS FROM BERTLY
+    		b.northstar_id AS northstar_id,
+    		b.click_time AS "timestamp",
+    		'sms_link_click' AS "action",
+    		'10' AS action_id,
+    		'bertly' AS "source",
+    		b.click_id AS action_serial_id
+    	FROM public.bertly_clicks b	
+    	WHERE b.northstar_id IS NOT NULL 
 		) AS a 
 	); 
 

--- a/Infrastructure/Scripts/derived_tables/MEL_v3.sql
+++ b/Infrastructure/Scripts/derived_tables/MEL_v3.sql
@@ -148,6 +148,16 @@ CREATE MATERIALIZED VIEW public.member_event_log AS
             pe.event_name IN ('share action completed', 'facebook share posted')
         AND pe.northstar_id IS NOT NULL
         AND pe.northstar_id <> ''
+	UNION ALL 
+    		SELECT -- SMS LINK CLICKS FROM BERTLY
+    			b.northstar_id AS northstar_id,
+    			b.click_time AS "timstamp",
+    			'sms_link_click' AS "action",
+    			'10' AS action_id,
+    			'bertly' AS "source",
+    			b.click_id AS action_serial_id
+    		FROM public.bertly_clicks b	
+    		WHERE b.northstar_id IS NOT NULL 
 		) AS a 
 	); 
 

--- a/Infrastructure/Scripts/derived_tables/MEL_v3.sql
+++ b/Infrastructure/Scripts/derived_tables/MEL_v3.sql
@@ -151,7 +151,7 @@ CREATE MATERIALIZED VIEW public.member_event_log AS
 	UNION ALL 
     		SELECT -- SMS LINK CLICKS FROM BERTLY
     			b.northstar_id AS northstar_id,
-    			b.click_time AS "timstamp",
+    			b.click_time AS "timestamp",
     			'sms_link_click' AS "action",
     			'10' AS action_id,
     			'bertly' AS "source",


### PR DESCRIPTION
* This PR adds bertly link clicks to the member event log so we can start tracking them in MAM counts and action count breakdowns

Ticket: https://www.pivotaltracker.com/story/show/158126302