### PR TITLE
nb looking at impact of post reattribution to 2018 rbs

### DIFF
--- a/KPIs/Scripts/rbAudit/requirements.txt
+++ b/KPIs/Scripts/rbAudit/requirements.txt
@@ -1,0 +1,6 @@
+jupyter==1.0.0
+matplotlib==3.0.0
+numpy==1.15.2
+pandas==0.23.4
+psycopg2==2.7.5
+seaborn==0.9.0

--- a/KPIs/Scripts/rbAudit/social_share_rb_qa.ipynb
+++ b/KPIs/Scripts/rbAudit/social_share_rb_qa.ipynb
@@ -1,0 +1,347 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.7/site-packages/psycopg2/__init__.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use \"pip install psycopg2-binary\" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.\n",
+      "  \"\"\")\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "import utils_gen as u"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conn = u.load_connection()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, look at the posts that we want to remove and determine what the impact will be to the 2018 rb count."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_remove = pd.read_csv('no_signup_posts.csv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "remove_posts = u.sql_stringify_list(df_remove['post_id'].values)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sqlremove = '''select * from campaign_activity where post_id in ({})'''.format(remove_posts)\n",
+    "df_ca_remove = pd.read_sql(sqlremove, conn)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2010-01-30 13:06:00    664\n",
+       "2010-02-15 22:25:00    437\n",
+       "2018-02-26 20:19:41     51\n",
+       "2018-03-27 22:47:38      5\n",
+       "Name: post_attribution_date, dtype: int64"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_ca_remove['post_attribution_date'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Most look like they were already being counted in 2010, so the total impact to 2018 will be -56 rbs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, let's look at what the impact will be once we correctly attribute posts to their signups. This requires confirming that those signup ids do not have any other social shares that would lead to double counting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_correct = pd.read_csv('fb_post_reattribution_ids.csv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "correct_posts = u.sql_stringify_list(df_correct['post_id'].values)\n",
+    "correct_signups = u.sql_int_list(df_correct['signup_id'].values)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sql_signups = '''select * from campaign_activity where signup_id in ({})'''.format(correct_signups)\n",
+    "df_signups = pd.read_sql(sql_signups, conn)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "voter-reg - may-2018-turbovote       445\n",
+       "photo - default                      205\n",
+       "text - default                        27\n",
+       "voter-reg - june-2018-turbovote       26\n",
+       "voter-reg - july-2018-turbovote        9\n",
+       "voter-reg - april-2018-turbovote       1\n",
+       "voter-reg - june-2014-rockthevote      1\n",
+       "Name: post_class, dtype: int64"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_signups['post_class'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Looks like there are records that don't have any posts associated with them. Let's see how many unique signup_ids don't have any posts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "null_signup_ids = set(df_signups[df_signups['post_class'].isnull()]['signup_id'].unique())\n",
+    "not_null_signup_ids = set(df_signups[df_signups['post_class'].notnull()]['signup_id'].unique())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(null_signup_ids & not_null_signup_ids)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(4498, 3922, 576)"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(df_signups['signup_id'].unique()), len(null_signup_ids), len(not_null_signup_ids)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "That's safe, so we know for sure that 3,923 of the 4,498 don't have any posts associated with them. Let's double check the 576."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "voter-reg - may-2018-turbovote       445\n",
+       "photo - default                      205\n",
+       "text - default                        27\n",
+       "voter-reg - june-2018-turbovote       26\n",
+       "voter-reg - july-2018-turbovote        9\n",
+       "voter-reg - april-2018-turbovote       1\n",
+       "voter-reg - june-2014-rockthevote      1\n",
+       "Name: post_class, dtype: int64"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_signups[df_signups['post_class'].notnull()]['post_class'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "None of these signup ids have social shares either, so all posts that need to be updated are the only social shares for their correct signup id. Final step is to look at impact for 2018."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sql_posts = '''select * from campaign_activity where post_id in ({})'''.format(correct_posts)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_posts = pd.read_sql(sql_posts, conn)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2010-02-15 22:25:00    3510\n",
+       "2010-01-30 13:06:00     972\n",
+       "2018-02-26 20:19:41     379\n",
+       "2018-03-27 22:47:38      63\n",
+       "2018-05-03 21:35:30      37\n",
+       "2018-05-02 18:46:03       4\n",
+       "2018-05-31 17:18:52       3\n",
+       "2018-05-11 15:29:52       2\n",
+       "2018-07-01 04:55:13       1\n",
+       "2018-05-30 19:30:10       1\n",
+       "2018-05-28 12:07:13       1\n",
+       "Name: post_attribution_date, dtype: int64"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_posts['post_attribution_date'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There will be some redistribution of these once they're using post created at dates, but from above will add 4482 rbs to 2018 totals (not including -56 from the first section or other cleanup from updated deduping)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/KPIs/Scripts/rbAudit/utils_gen.py
+++ b/KPIs/Scripts/rbAudit/utils_gen.py
@@ -1,0 +1,57 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import os
+import pandas as pd
+import psycopg2
+import seaborn as sns
+from collections import OrderedDict
+
+
+def print_null_vals(df):
+    null_vals = []
+    for col in df.columns:
+        if df[col].dtype == 'object': 
+            null_val = sum(df[col].isnull()) + sum(df[col] == '') + sum(df[col] == '0')
+        if df[col].dtype == 'datetime64[ns]':
+            null_val = sum(df[col].isnull()) + sum(df[col] == '')
+        if df[col].dtype == 'float64' or df[col].dtype == 'int64':
+            null_val = sum(df[col].isnull())
+        null_vals.append(null_val)
+
+    df_nulls = pd.DataFrame({
+        'col': df.columns,
+        'num_null': null_vals,
+        'percent_null': list(np.array(null_vals) / len(df))
+    })
+
+    return df_nulls
+
+
+def load_connection(
+        db_user='DB_USER',
+        db_pw='DB_PW',
+        db_name='DB_NAME',
+        db_host='DB_HOST'):
+    user = os.environ.get(db_user)
+    pwd = os.environ.get(db_pw)
+    db = os.environ.get(db_name)
+    host = os.environ.get(db_host)
+    return psycopg2.connect(database=db, user=user, password=pwd, host=host)
+
+
+def sql_stringify_list(li):
+    sql_str = ''
+
+    if isinstance(li[0], str):
+        for l in li:
+            if l != li[-1]:
+                sql_str += "'" + l + "', "
+            else:
+                sql_str += "'" + l + "'"
+    else:
+        for l in li:
+            if l != li[-1]:
+                sql_str += str(int(l)) + ", "
+            else:
+                sql_str += str(int(l))
+    return sql_str


### PR DESCRIPTION
#### What's this PR do?
Investigates whether social share posts that need to be correctly attributed are the only social share for their correct signup_id. This would allow us to use the incorrect signup id in the new rb logic without worrying about double counting.
 
#### How should this be manually tested?
I can provide the csvs required to run the notebook. 

#### Any background context you want to provide?
This is part of creating the new logic for reportbacks, which dedupes by signup_id, post_class, and reportback_volume. Because these misattributed signup_ids were all reset to -1, they were not being counted in the new logic. The hope is to be able to use the incorrect signup id without worrying that this might lead to overcounting if the correct signup id already has a social share associated with it.
