### PR TITLE
query for number of undeliverable users  by broadcast and error code

### DIFF
--- a/AdHoc/Scripts/gambitUndeliverability.sql
+++ b/AdHoc/Scripts/gambitUndeliverability.sql
@@ -4,8 +4,8 @@ SELECT 	g1.broadcast_id,
 	count(DISTINCT g1.user_id) AS num_users
 FROM (
 	SELECT  g.broadcast_id,
-		CASE WHEN (g.metadata ->> 'delivery')::json ->> 'failureData' IS NOT NULL
-		THEN (g.metadata #> '{delivery, failureData}')::json ->> 'code'
+		CASE WHEN (g.metadata #> '{delivery}') ->> 'failureData' IS NOT NULL
+		THEN (g.metadata #> '{delivery, failureData}') ->> 'code'
 		ELSE '0' END AS failure_code,
 		g.user_id
 	FROM (

--- a/AdHoc/Scripts/gambitUndeliverability.sql
+++ b/AdHoc/Scripts/gambitUndeliverability.sql
@@ -1,0 +1,18 @@
+-- returns count of users by broadcast and error code where an error code of 0 means no error --
+SELECT 	g1.broadcast_id,
+	g1.failure_code,
+	count(DISTINCT g1.user_id) AS num_users
+FROM (
+	SELECT  g.broadcast_id,
+		CASE WHEN (g.metadata ->> 'delivery')::json ->> 'failureData' IS NOT NULL
+		THEN (g.metadata #> '{delivery, failureData}')::json ->> 'code'
+		ELSE '0' END AS failure_code,
+		g.user_id
+	FROM (
+		SELECT records ->> 'broadcastId' AS broadcast_id, cast(records ->> 'metadata' AS json) AS metadata, records ->> 'userId' AS user_id
+		FROM gambit.messages_json
+	) g
+	WHERE g.broadcast_id IN () -- add broadcast ids --
+) g1
+WHERE g1.failure_code IN ('30003', '21610','21614','21606','30008','21612','30004','21211', '30006', '0')
+GROUP BY g1.broadcast_id, g1.failure_code


### PR DESCRIPTION
#### What's this PR do?
general query that can be used to find the number of undeliverable users by broadcast and error code

#### What are the relevant tickets/trello cards?
https://trello.com/c/6kVl0ygB/1458-error-codes-from-gambit-over-past-2-months
